### PR TITLE
Review Service - 벌크 연산 적용

### DIFF
--- a/src/main/java/com/beforehairshop/demo/review/domain/ReviewHashtag.java
+++ b/src/main/java/com/beforehairshop/demo/review/domain/ReviewHashtag.java
@@ -41,4 +41,10 @@ public class ReviewHashtag {
         this.hashtag = hashtag;
         this.status = status;
     }
+
+    public ReviewHashtag(String hashtag, Review review, Integer status) {
+        this.hashtag = hashtag;
+        this.review = review;
+        this.status = status;
+    }
 }

--- a/src/main/java/com/beforehairshop/demo/review/service/ReviewService.java
+++ b/src/main/java/com/beforehairshop/demo/review/service/ReviewService.java
@@ -102,27 +102,27 @@ public class ReviewService {
 
         List<ReviewDetailResponseDto> reviewDetailResponseDtoList = new ArrayList<>();
         for (Review review : reviewList) {
-            List<ReviewHashtagDto> hashtagDtoList = reviewHashtagRepository.findByReviewAndStatus(review, StatusKind.NORMAL.getId())
-                    .stream()
-                    .map(ReviewHashtagDto::new)
-                    .collect(Collectors.toList());
-
-            List<ReviewImageDto> imageDtoList = reviewImageRepository.findByReviewAndStatus(review, StatusKind.NORMAL.getId())
-                    .stream()
-                    .map(ReviewImageDto::new)
-                    .collect(Collectors.toList());
-
-            if (review.getReviewer().getName() == null)
-                continue;
-
-            reviewDetailResponseDtoList.add(new ReviewDetailResponseDto(review.getReviewer().getName()
-                    , new ReviewDto(review)
-                    , hashtagDtoList
-                    , imageDtoList));
+//            List<ReviewHashtagDto> hashtagDtoList = reviewHashtagRepository.findByReviewAndStatus(review, StatusKind.NORMAL.getId())
+//                    .stream()
+//                    .map(ReviewHashtagDto::new)
+//                    .collect(Collectors.toList());
+//
+//            List<ReviewImageDto> imageDtoList = reviewImageRepository.findByReviewAndStatus(review, StatusKind.NORMAL.getId())
+//                    .stream()
+//                    .map(ReviewImageDto::new)
+//                    .collect(Collectors.toList());
+//
+//            if (review.getReviewer().getName() == null)
+//                continue;
+//
 //            reviewDetailResponseDtoList.add(new ReviewDetailResponseDto(review.getReviewer().getName()
 //                    , new ReviewDto(review)
-//                    , review.getReviewHashtagSet().stream().map(ReviewHashtagDto::new).collect(Collectors.toList())
-//                    , review.getReviewImageSet().stream().map(ReviewImageDto::new).collect(Collectors.toList())));
+//                    , hashtagDtoList
+//                    , imageDtoList));
+            reviewDetailResponseDtoList.add(new ReviewDetailResponseDto(review.getReviewer().getName()
+                    , new ReviewDto(review)
+                    , review.getReviewHashtagSet().stream().map(ReviewHashtagDto::new).collect(Collectors.toList())
+                    , review.getReviewImageSet().stream().map(ReviewImageDto::new).collect(Collectors.toList())));
         }
 
         return makeResult(HttpStatus.OK, reviewDetailResponseDtoList);

--- a/src/main/java/com/beforehairshop/demo/review/service/ReviewService.java
+++ b/src/main/java/com/beforehairshop/demo/review/service/ReviewService.java
@@ -252,8 +252,7 @@ public class ReviewService {
 //            reviewImageRepository.delete(reviewImage);
             }
 
-            for (ReviewImage reviewImage : reviewImageList)
-                review.getReviewImageSet().remove(reviewImage);
+            reviewImageRepository.deleteAllInBatch(reviewImageList);
         }
 
         // 프론트엔드에서 요청한 이미지의 개수만큼 presigned url 을 만들어 리턴한다.

--- a/src/main/java/com/beforehairshop/demo/review/service/ReviewService.java
+++ b/src/main/java/com/beforehairshop/demo/review/service/ReviewService.java
@@ -159,11 +159,9 @@ public class ReviewService {
             review.setContent(reviewPatchRequestDto.getContent());
 
         if (reviewPatchRequestDto.getHashtagList() != null) {
-            // review hash tag 삭제
-            review.getReviewHashtagSet().clear();
-
+            // review hashtag 삭제
 //            List<ReviewHashtag> reviewHashtagList = reviewHashtagRepository.findByReviewAndStatus(review, StatusKind.NORMAL.getId());
-//            reviewHashtagRepository.deleteAllInBatch(reviewHashtagList);
+            reviewHashtagRepository.deleteAllInBatch(review.getReviewHashtagSet());
 
             // review hash tag 생성
             for (ReviewHashtagPatchRequestDto patchRequestDto : reviewPatchRequestDto.getHashtagList()) {
@@ -172,10 +170,6 @@ public class ReviewService {
                 review.addReviewHashtag(reviewHashtag);
             }
 
-//            reviewHashtagRepository.saveAll(reviewPatchRequestDto.getHashtagList()
-//                    .stream()
-//                    .map(reviewHashtagPatchRequestDto -> reviewHashtagPatchRequestDto.toEntity(review))
-//                    .collect(Collectors.toList()));
         }
 
         return makeResult(HttpStatus.OK, new ReviewDto(review));

--- a/src/test/java/com/beforehairshop/demo/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/beforehairshop/demo/review/service/ReviewServiceTest.java
@@ -6,6 +6,8 @@ import com.beforehairshop.demo.member.service.MemberService;
 import com.beforehairshop.demo.response.ResultDto;
 import com.beforehairshop.demo.review.dto.ReviewHashtagDto;
 import com.beforehairshop.demo.review.dto.ReviewImageDto;
+import com.beforehairshop.demo.review.dto.patch.ReviewHashtagPatchRequestDto;
+import com.beforehairshop.demo.review.dto.patch.ReviewPatchRequestDto;
 import com.beforehairshop.demo.review.dto.response.ReviewDetailResponseDto;
 import com.beforehairshop.demo.review.dto.save.ReviewHashtagSaveRequestDto;
 import com.beforehairshop.demo.review.dto.save.ReviewSaveRequestDto;
@@ -108,8 +110,23 @@ class ReviewServiceTest {
 
     }
 
+    // (기존) 1008ms, 980ms => (delete batch) 829ms, 889ms
+    //
     @Test
-    public void ff() {
+    public void patchReview() {
+        ArrayList<ReviewHashtagPatchRequestDto> hashtagList = new ArrayList<>();
+        hashtagList.add(new ReviewHashtagPatchRequestDto("새로운컷1"));
+        hashtagList.add(new ReviewHashtagPatchRequestDto("새로운컷2"));
+        hashtagList.add(new ReviewHashtagPatchRequestDto("새로운컷3"));
 
+
+        ResponseEntity<ResultDto> response = reviewService.patchOne(new Member(BigInteger.valueOf(9)), BigInteger.valueOf(1), new ReviewPatchRequestDto(4, 4, 4, "컨텐츠 수정후",
+                hashtagList)
+        );
+
+        em.flush();
+        em.clear();
     }
+
+
 }

--- a/src/test/java/com/beforehairshop/demo/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/beforehairshop/demo/review/service/ReviewServiceTest.java
@@ -4,6 +4,7 @@ import com.beforehairshop.demo.member.domain.Member;
 import com.beforehairshop.demo.member.dto.MemberDto;
 import com.beforehairshop.demo.member.service.MemberService;
 import com.beforehairshop.demo.response.ResultDto;
+import com.beforehairshop.demo.review.dto.ReviewDto;
 import com.beforehairshop.demo.review.dto.ReviewHashtagDto;
 import com.beforehairshop.demo.review.dto.ReviewImageDto;
 import com.beforehairshop.demo.review.dto.patch.ReviewHashtagPatchRequestDto;
@@ -27,6 +28,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -86,28 +88,31 @@ class ReviewServiceTest {
         hashtagList.add(new ReviewHashtagSaveRequestDto("스포츠컷"));
         hashtagList.add(new ReviewHashtagSaveRequestDto("박서준컷"));
 
-        reviewService.save(new Member(findMemberDto.getId()), new ReviewSaveRequestDto(
+        ResponseEntity<ResultDto> response = reviewService.save(new Member(findMemberDto.getId()), new ReviewSaveRequestDto(
                 BigInteger.valueOf(1), 5, 5, 5, "테스트 콘텐츠!",  hashtagList
         ));
+
+        ReviewDto reviewDto = (ReviewDto) response.getBody().getResult();
+
+        assertThat(reviewDto.getReviewerId()).isEqualTo(9);
+        assertThat(reviewDto.getServiceRating()).isEqualTo(5);
+        assertThat(reviewDto.getTotalRating()).isEqualTo(5);
+        assertThat(reviewDto.getStyleRating()).isEqualTo(5);
+        assertThat(reviewDto.getContent()).isEqualTo("테스트 콘텐츠!");
     }
 
     @Test
     public void findReviews() {
-        ResponseEntity<ResultDto> response = reviewService.findManyByHairDesigner(new Member(BigInteger.valueOf(1)), BigInteger.valueOf(1), PageRequest.of(0, 3));
+        ResponseEntity<ResultDto> response = reviewService.findManyByHairDesigner(new Member(BigInteger.valueOf(1)), BigInteger.valueOf(1), PageRequest.of(0, 2));
         List<ReviewDetailResponseDto> reviewList = (List<ReviewDetailResponseDto>) response.getBody().getResult();
 
         for (ReviewDetailResponseDto responseDto : reviewList) {
-            System.out.println(responseDto.getReviewDto().getContent());
-            System.out.println("hashtag list's size : " + responseDto.getHashtagDtoList().size());
-            for (ReviewHashtagDto hashtagDto : responseDto.getHashtagDtoList()) {
-                System.out.println(" > hashtag : " + hashtagDto.getHashtag());
-            }
-            System.out.println("review image list's size : " + responseDto.getImageDtoList().size());
-            for (ReviewImageDto imageDto : responseDto.getImageDtoList()) {
-                System.out.println(" > image : " + imageDto.getImageUrl());
-            }
+            assertThat(responseDto.getHashtagDtoList().size()).isEqualTo(2);
+
+            assertThat(responseDto.getImageDtoList().size()).isEqualTo(0);
         }
 
+        assertThat(reviewList.size()).isEqualTo(2);
     }
 
     // (기존) 1008ms, 980ms => (delete batch) 829ms, 889ms
@@ -126,6 +131,14 @@ class ReviewServiceTest {
 
         em.flush();
         em.clear();
+
+        ReviewDto reviewDto = (ReviewDto) response.getBody().getResult();
+
+        assertThat(reviewDto.getContent()).isEqualTo("컨텐츠 수정후");
+        assertThat(reviewDto.getServiceRating()).isEqualTo(4);
+        assertThat(reviewDto.getTotalRating()).isEqualTo(4);
+        assertThat(reviewDto.getStyleRating()).isEqualTo(4);
+
     }
 
 


### PR DESCRIPTION
## 개발사항
- 리뷰 엔티티 관련 `해시태그 엔티티 리스트` 수정 시, 기존 해시태그 리스트를 삭제할 때 `벌크 연산(bulk delete)`으로 성능 최적화
- 리뷰 엔티티 관련 `이미지 리스트` 수정 시, 기존 이미지 리스트를 삭제할 때 `벌크 연산(bulk delete)`으로 성능 최적화
- `@BatchSize` 적용 전 코드가 머지돼서 수정 #76 
- close #78 