### PR TITLE
[Refactoring] MemberService 비즈니스 로직 성능최적화

### DIFF
--- a/src/main/java/com/beforehairshop/demo/member/domain/MemberProfile.java
+++ b/src/main/java/com/beforehairshop/demo/member/domain/MemberProfile.java
@@ -29,7 +29,7 @@ public class MemberProfile {
     @Column(columnDefinition = "BIGINT")
     private BigInteger id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/beforehairshop/demo/member/repository/MemberProfileRepository.java
+++ b/src/main/java/com/beforehairshop/demo/member/repository/MemberProfileRepository.java
@@ -4,6 +4,7 @@ import com.beforehairshop.demo.member.domain.Member;
 import com.beforehairshop.demo.member.domain.MemberProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.math.BigInteger;
 import java.util.List;

--- a/src/main/java/com/beforehairshop/demo/member/repository/MemberProfileRepository.java
+++ b/src/main/java/com/beforehairshop/demo/member/repository/MemberProfileRepository.java
@@ -21,4 +21,6 @@ public interface MemberProfileRepository extends JpaRepository<MemberProfile, Bi
 
     Optional<MemberProfile> findByIdAndStatus(BigInteger memberProfileId, Integer id);
 
+    @Query(value = "select mp from MemberProfile mp join fetch mp.member where mp.id = :memberProfileId and mp.status = :status")
+    Optional<MemberProfile> findMemberAndProfileByIdAndStatusUsingFetchJoin(@Param("memberProfileId") BigInteger memberProfileId, @Param("status") Integer status);
 }

--- a/src/main/java/com/beforehairshop/demo/member/service/MemberService.java
+++ b/src/main/java/com/beforehairshop/demo/member/service/MemberService.java
@@ -371,7 +371,7 @@ public class MemberService {
             memberProfile.setBackImageUrl(cloudFrontUrlHandler.getProfileOfUserImageUrl(member.getId(), "back"));
         }
 
-        Member updatedMember = memberRepository.findByIdAndStatus(member.getId(), StatusKind.NORMAL.getId()).orElse(null);
+        Member updatedMember = memberProfile.getMember();
 
         updatedMember.setImageUrl(cloudFrontUrlHandler.getProfileOfUserImageUrl(member.getId(), "front"));
         PrincipalDetailsUpdater.setAuthenticationOfSecurityContext(updatedMember, "ROLE_USER");

--- a/src/test/java/com/beforehairshop/demo/member/service/MemberServiceTest.java
+++ b/src/test/java/com/beforehairshop/demo/member/service/MemberServiceTest.java
@@ -7,22 +7,25 @@ import com.beforehairshop.demo.member.dto.MemberProfileDto;
 import com.beforehairshop.demo.member.dto.post.MemberProfileSaveRequestDto;
 import com.beforehairshop.demo.member.dto.post.MemberSaveRequestDto;
 import com.beforehairshop.demo.member.dto.response.MemberProfileDetailResponseDto;
+import com.beforehairshop.demo.member.repository.MemberProfileRepository;
+import com.beforehairshop.demo.member.repository.MemberRepository;
 import com.beforehairshop.demo.oauth.dto.post.AppleUserSaveRequestDto;
 import com.beforehairshop.demo.oauth.service.OAuthService;
 import com.beforehairshop.demo.response.ResultDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
+import javax.persistence.*;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -35,10 +38,16 @@ class MemberServiceTest {
     MemberService memberService;
 
     @Autowired
+    MemberProfileRepository memberProfileRepository;
+
+    @Autowired
     OAuthService oAuthService;
 
     @PersistenceContext
     EntityManager em;
+
+    @Autowired
+    EntityManagerFactory emf;
 
     @Test
     public void findMyProfileTest() {
@@ -61,5 +70,16 @@ class MemberServiceTest {
 
         assertThat(responseDto.getMemberProfileDto().getId()).isEqualTo(memberProfileId);
     }
+
+    @Test
+    @DisplayName("MemberProfile 엔티티와 Member 엔티티를 fetch join 으로 조회되는지 테스트")
+    public void memberAndMemberProfileByFetchJoinTest() {
+        Optional<MemberProfile> memberProfile = memberProfileRepository.findMemberAndProfileByIdAndStatusUsingFetchJoin(BigInteger.valueOf(1), StatusKind.NORMAL.getId());
+
+        assertThat(memberProfile).isNotNull();
+        assertThat(emf.getPersistenceUnitUtil().isLoaded(memberProfile.get().getMember())).isEqualTo(true);
+    }
+
+
 
 }

--- a/src/test/java/com/beforehairshop/demo/member/service/MemberServiceTest.java
+++ b/src/test/java/com/beforehairshop/demo/member/service/MemberServiceTest.java
@@ -41,13 +41,25 @@ class MemberServiceTest {
     EntityManager em;
 
     @Test
-    public void findProfileTest() {
+    public void findMyProfileTest() {
         Member member = new Member(BigInteger.valueOf(9));
 
         ResponseEntity<ResultDto> profileResponse = memberService.findMyProfile(member);
         MemberProfileDetailResponseDto memberProfileDto = (MemberProfileDetailResponseDto) profileResponse.getBody().getResult();
 
         assertThat(memberProfileDto.getMemberProfileDto().getMemberId()).isEqualTo(9);
+    }
+
+    @Test
+    public void findMemberProfileBySomeone() {
+        Member someone = new Member(BigInteger.valueOf(1));
+
+        BigInteger memberProfileId = BigInteger.valueOf(1);
+        ResponseEntity<ResultDto> response = memberService.findMemberProfile(someone, memberProfileId);
+
+        MemberProfileDetailResponseDto responseDto = (MemberProfileDetailResponseDto) response.getBody().getResult();
+
+        assertThat(responseDto.getMemberProfileDto().getId()).isEqualTo(memberProfileId);
     }
 
 }


### PR DESCRIPTION
## 개발사항
- MemberProfile 엔티티와 Member 엔티티가 즉시로딩으로 연관관계를 맺고 있었음
  - 지연로딩(Lazy loading) 으로 수정 > **의도치 않는 성능 저하 막기 위해서**
- Fetch join을 활용해서 성능 최적화
- [ ] #80